### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If KubeShark helps your project, please consider:
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LukasNiessen/kubernetes-skill&type=Date)](https://www.star-history.com/#LukasNiessen/kubernetes-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LukasNiessen/kubernetes-skill&type=Date)](https://star-history.dera.page/#LukasNiessen/kubernetes-skill&Date)
 
 ## License
 


### PR DESCRIPTION
Replaces the broken Star History image and destination URLs with the working star-history.dera.page endpoints, matching ArchUnitTS PR #89.