### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If KubeShark helps your project, please consider:
 
 ### Star History
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=LukasNiessen/kubernetes-skill&type=Date)](https://star-history.dera.page/#LukasNiessen/kubernetes-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LukasNiessen/kubernetes-skill&type=date)](https://star-history.dera.page/#LukasNiessen/kubernetes-skill&type=date)
 
 ## License
 


### PR DESCRIPTION
The star history chart is currently broken, so this updates the chart links to the working format. The GitHub stars badge is unchanged.